### PR TITLE
Murisi/updating sdk usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ futures = "0.3.28"
 getrandom = { version = "0.2" }
 masp_primitives = { git = "https://github.com/anoma/masp.git", rev = "50acc5028fbcd52a05970fe7991c7850ab04358e" }
 masp_proofs = { git = "https://github.com/anoma/masp.git", rev = "50acc5028fbcd52a05970fe7991c7850ab04358e", features = ["download-params"]}
-namada = { git = "https://github.com/anoma/namada.git", rev = "af3a2a8335fea551973f18d72bf7cb8a6d047517", default-features = false, features = ["abciplus", "namada-sdk"] }
+namada = { git = "https://github.com/anoma/namada.git", rev = "74aeca785e47216eb7611d1b6b97fcd59b2fffad", default-features = false, features = ["abciplus", "namada-sdk", "std"] }
 rand = {version = "0.8", default-features = false}
 rand_core = {version = "0.6", default-features = false}
 tendermint-config = {git="https://github.com/heliaxdev/tendermint-rs.git", rev="b7d1e5afc6f2ccb3fd1545c2174bab1cc48d7fa7"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ futures = "0.3.28"
 getrandom = { version = "0.2" }
 masp_primitives = { git = "https://github.com/anoma/masp.git", rev = "50acc5028fbcd52a05970fe7991c7850ab04358e" }
 masp_proofs = { git = "https://github.com/anoma/masp.git", rev = "50acc5028fbcd52a05970fe7991c7850ab04358e", features = ["download-params"]}
-namada = { git = "https://github.com/anoma/namada.git", rev = "123b5ed305c332761717e7b2757e662254b814a9", default-features = false, features = ["abciplus", "namada-sdk", "std"] }
+namada = { git = "https://github.com/anoma/namada.git", rev = "ffff55bbb606e3d63cb862a5fed62e8f2ce32433", default-features = false, features = ["abciplus", "namada-sdk", "std"] }
 rand = {version = "0.8", default-features = false}
 rand_core = {version = "0.6", default-features = false}
 tendermint-config = {git="https://github.com/heliaxdev/tendermint-rs.git", rev="b7d1e5afc6f2ccb3fd1545c2174bab1cc48d7fa7"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ futures = "0.3.28"
 getrandom = { version = "0.2" }
 masp_primitives = { git = "https://github.com/anoma/masp.git", rev = "50acc5028fbcd52a05970fe7991c7850ab04358e" }
 masp_proofs = { git = "https://github.com/anoma/masp.git", rev = "50acc5028fbcd52a05970fe7991c7850ab04358e", features = ["download-params"]}
-namada = { git = "https://github.com/anoma/namada.git", rev = "615ebc8e7dbf3531c446f60ec7ac77676aef3b63", default-features = false, features = ["abciplus", "namada-sdk", "std"] }
+namada_sdk = { git = "https://github.com/anoma/namada.git", rev = "94b2d4bdd0b4d668db7cf4e10358ba1a5cb98db4", default-features = false, features = ["abciplus", "namada-sdk", "std"] }
 rand = {version = "0.8", default-features = false}
 rand_core = {version = "0.6", default-features = false}
 tendermint-config = {git="https://github.com/heliaxdev/tendermint-rs.git", rev="b7d1e5afc6f2ccb3fd1545c2174bab1cc48d7fa7"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ futures = "0.3.28"
 getrandom = { version = "0.2" }
 masp_primitives = { git = "https://github.com/anoma/masp.git", rev = "50acc5028fbcd52a05970fe7991c7850ab04358e" }
 masp_proofs = { git = "https://github.com/anoma/masp.git", rev = "50acc5028fbcd52a05970fe7991c7850ab04358e", features = ["download-params"]}
-namada = { git = "https://github.com/anoma/namada.git", rev = "ffff55bbb606e3d63cb862a5fed62e8f2ce32433", default-features = false, features = ["abciplus", "namada-sdk", "std"] }
+namada = { git = "https://github.com/anoma/namada.git", rev = "db24f6afcb6b20743cee656393c5805b9768e703", default-features = false, features = ["abciplus", "namada-sdk", "std"] }
 rand = {version = "0.8", default-features = false}
 rand_core = {version = "0.6", default-features = false}
 tendermint-config = {git="https://github.com/heliaxdev/tendermint-rs.git", rev="b7d1e5afc6f2ccb3fd1545c2174bab1cc48d7fa7"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ futures = "0.3.28"
 getrandom = { version = "0.2" }
 masp_primitives = { git = "https://github.com/anoma/masp.git", rev = "50acc5028fbcd52a05970fe7991c7850ab04358e" }
 masp_proofs = { git = "https://github.com/anoma/masp.git", rev = "50acc5028fbcd52a05970fe7991c7850ab04358e", features = ["download-params"]}
-namada = { git = "https://github.com/anoma/namada.git", rev = "b1bc8450eca547827010532d50375a23c80e75a3", default-features = false, features = ["abciplus", "namada-sdk", "std"] }
+namada = { git = "https://github.com/anoma/namada.git", rev = "615ebc8e7dbf3531c446f60ec7ac77676aef3b63", default-features = false, features = ["abciplus", "namada-sdk", "std"] }
 rand = {version = "0.8", default-features = false}
 rand_core = {version = "0.6", default-features = false}
 tendermint-config = {git="https://github.com/heliaxdev/tendermint-rs.git", rev="b7d1e5afc6f2ccb3fd1545c2174bab1cc48d7fa7"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ futures = "0.3.28"
 getrandom = { version = "0.2" }
 masp_primitives = { git = "https://github.com/anoma/masp.git", rev = "50acc5028fbcd52a05970fe7991c7850ab04358e" }
 masp_proofs = { git = "https://github.com/anoma/masp.git", rev = "50acc5028fbcd52a05970fe7991c7850ab04358e", features = ["download-params"]}
-namada = { git = "https://github.com/anoma/namada.git", rev = "74aeca785e47216eb7611d1b6b97fcd59b2fffad", default-features = false, features = ["abciplus", "namada-sdk", "std"] }
+namada = { git = "https://github.com/anoma/namada.git", rev = "123b5ed305c332761717e7b2757e662254b814a9", default-features = false, features = ["abciplus", "namada-sdk", "std"] }
 rand = {version = "0.8", default-features = false}
 rand_core = {version = "0.6", default-features = false}
 tendermint-config = {git="https://github.com/heliaxdev/tendermint-rs.git", rev="b7d1e5afc6f2ccb3fd1545c2174bab1cc48d7fa7"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ futures = "0.3.28"
 getrandom = { version = "0.2" }
 masp_primitives = { git = "https://github.com/anoma/masp.git", rev = "50acc5028fbcd52a05970fe7991c7850ab04358e" }
 masp_proofs = { git = "https://github.com/anoma/masp.git", rev = "50acc5028fbcd52a05970fe7991c7850ab04358e", features = ["download-params"]}
-namada = { git = "https://github.com/anoma/namada.git", rev = "db24f6afcb6b20743cee656393c5805b9768e703", default-features = false, features = ["abciplus", "namada-sdk", "std"] }
+namada = { git = "https://github.com/anoma/namada.git", rev = "b1bc8450eca547827010532d50375a23c80e75a3", default-features = false, features = ["abciplus", "namada-sdk", "std"] }
 rand = {version = "0.8", default-features = false}
 rand_core = {version = "0.6", default-features = false}
 tendermint-config = {git="https://github.com/heliaxdev/tendermint-rs.git", rev="b7d1e5afc6f2ccb3fd1545c2174bab1cc48d7fa7"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,13 @@ borsh = "0.9.0"
 file-lock = "2.0.2"
 futures = "0.3.28"
 getrandom = { version = "0.2" }
-masp_primitives = { git = "https://github.com/anoma/masp.git", rev = "cfea8c95d3f73077ca3e25380fd27e5b46e828fd" }
-masp_proofs = { git = "https://github.com/anoma/masp.git", rev = "cfea8c95d3f73077ca3e25380fd27e5b46e828fd", features = ["download-params"]}
-namada = { path = "../namada/shared", default-features = false, features = ["abciplus", "namada-sdk"] }
+masp_primitives = { git = "https://github.com/anoma/masp.git", rev = "50acc5028fbcd52a05970fe7991c7850ab04358e" }
+masp_proofs = { git = "https://github.com/anoma/masp.git", rev = "50acc5028fbcd52a05970fe7991c7850ab04358e", features = ["download-params"]}
+namada = { git = "https://github.com/anoma/namada.git", rev = "af3a2a8335fea551973f18d72bf7cb8a6d047517", default-features = false, features = ["abciplus", "namada-sdk"] }
 rand = {version = "0.8", default-features = false}
 rand_core = {version = "0.6", default-features = false}
-tendermint-config = {git="https://github.com/heliaxdev/tendermint-rs.git", rev="02b256829e80f8cfecf3fa0d625c2a76c79cd043"}
-tendermint-rpc = {git="https://github.com/heliaxdev/tendermint-rs.git", rev="02b256829e80f8cfecf3fa0d625c2a76c79cd043", features = ["http-client"]}
+tendermint-config = {git="https://github.com/heliaxdev/tendermint-rs.git", rev="b7d1e5afc6f2ccb3fd1545c2174bab1cc48d7fa7"}
+tendermint-rpc = {git="https://github.com/heliaxdev/tendermint-rs.git", rev="b7d1e5afc6f2ccb3fd1545c2174bab1cc48d7fa7", features = ["http-client"]}
 thiserror = "1.0.38"
 tokio = {version = "1.8.2", default-features = false}
 toml = "0.5.8"

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,17 +3,16 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::{thread, time, vec};
+use std::future::Future;
+use futures::future::join_all;
+use std::pin::Pin;
 
 use rand::Rng;
-use rand_core::OsRng;
 use tendermint_config::net::Address as TendermintAddress;
 use tendermint_rpc::HttpClient;
 use zeroize::Zeroizing;
 
 use namada::bip39::Mnemonic;
-use namada::ledger::wallet::alias::Alias;
-use namada::ledger::wallet::Wallet;
-use namada::ledger::wallet::{store, GenRestoreKeyError};
 use namada::ledger::wallet::fs::FsWalletUtils;
 use namada::ledger::rpc;
 use namada::ledger::masp::fs::FsShieldedUtils;
@@ -27,7 +26,6 @@ use namada::ledger::NamadaImpl;
 use namada::ledger::Namada;
 use namada::ledger::args::TxBuilder;
 use namada::ledger::tx::ProcessTxResponse;
-use namada::types::token::DenominatedAmount;
 use namada::ledger::args::InputAmount;
 use namada::types::uint::Uint;
 use namada::ledger::rpc::denominate_amount;
@@ -72,22 +70,23 @@ struct Account {
 // - it's NAM balance
 // - check if it's PK has been revealed and if not, reveal it, otherwise reveal them
 // - returns a list of futures with potential revelations that need to be run first and update the account structure - this should only happen on the very first run
-fn gen_accounts<'a>(namada: &mut impl Namada<'a>, size: usize) -> Vec<Account> {
+async fn gen_accounts<'a>(namada: &mut impl Namada<'a>, size: usize) -> Vec<Account> {
     let mut accounts: Vec<Account> = vec![];
+    let mnemonic = Mnemonic::from_phrase(MNEMONIC_CODE, namada::bip39::Language::English)
+        .expect("unable to construct mnemonic");
 
     for i in 0..size {
         let derivation_path = format!("m/44'/877'/0'/0'/{}'", i);
         let alias = format!("default_{}", i);
-        let mnemonic = Mnemonic::from_phrase(MNEMONIC_CODE, namada::bip39::Language::English)
-            .expect("unable to construct mnemonic");
         let (key_alias, sk) = namada
-            .wallet
+            .wallet_mut()
+            .await
             .derive_key_from_user_mnemonic_code(
                 SchemeType::Ed25519,
                 Some(alias),
                 false,
                 Some(derivation_path),
-                Some((mnemonic, Zeroizing::new("".to_owned()))),
+                Some((mnemonic.clone(), Zeroizing::new("".to_owned()))),
                 None,
             )
             .expect("unable to derive key from mnemonic code")
@@ -101,18 +100,18 @@ fn gen_accounts<'a>(namada: &mut impl Namada<'a>, size: usize) -> Vec<Account> {
         };
         accounts.push(account);
     }
-    namada.wallet.save().expect("unable to save wallet");
+    namada.wallet().await.save().expect("unable to save wallet");
     accounts
 }
 
 async fn update_token_balances<'a>(
-    namada: &mut impl Namada<'a>,
+    namada: &impl Namada<'a>,
     accounts: &mut Vec<Account>,
 ) {
     for account in accounts {
         account.balance = rpc::get_token_balance(
-            namada.client,
-            &namada.native_token(),
+            namada.client(),
+            &namada.native_token().await,
             &Address::from(&account.public_key),
         )
         .await.expect("unable to query account balance");
@@ -129,26 +128,26 @@ async fn reveal_pks<'a>(
     for mut account in accounts {
         let reveal_tx_builder = namada
             .new_reveal_pk(account.public_key.clone())
+            .await
             .signing_keys(vec![account.private_key.clone()]);
         let (mut reveal_tx, signing_data, _) = reveal_tx_builder
             .build(namada)
             .await
             .expect("unable to build reveal pk tx");
         namada.sign(&mut reveal_tx, &reveal_tx_builder.tx, signing_data)
+            .await
             .expect("unable to sign reveal pk tx");
         let res = namada.submit(reveal_tx, &reveal_tx_builder.tx).await;
-        if res.is_ok() {
-            account.revealed = true;
-        }
+        account.revealed |= res.is_ok();
     }
 }
 
 async fn get_funds_from_faucet<'a>(
-    namada: &mut impl Namada<'a>,
+    namada: &impl Namada<'a>,
     account: &Account,
 ) -> std::result::Result<ProcessTxResponse, namada::types::error::Error> {
     let faucet = Address::from_str(FAUCET).unwrap();
-    let native_token = namada.native_token();
+    let native_token = namada.native_token().await;
 
     let mut transfer_tx_builder = namada.new_transfer(
         TransferSource::Address(faucet.clone()),
@@ -156,23 +155,25 @@ async fn get_funds_from_faucet<'a>(
         native_token,
         InputAmount::from_str("1000").unwrap(),
     )
+        .await
         .signing_keys(vec![account.private_key.clone()]);
     let (mut transfer_tx, signing_data, _epoch) = transfer_tx_builder
         .build(namada)
         .await
         .expect("unable to build transfer");
     namada.sign(&mut transfer_tx, &transfer_tx_builder.tx, signing_data)
-            .expect("unable to sign reveal pk tx");
+        .await
+        .expect("unable to sign reveal pk tx");
     namada.submit(transfer_tx, &transfer_tx_builder.tx).await
 }
 
 async fn gen_transfer<'a>(
-    namada: &mut impl Namada<'a>,
+    namada: &impl Namada<'a>,
     source: &Account,
     destination: &Account,
     amount: InputAmount,
 ) -> std::result::Result<ProcessTxResponse, namada::types::error::Error> {
-    let native_token = namada.native_token();
+    let native_token = namada.native_token().await;
     
     let mut transfer_tx_builder = namada.new_transfer(
         TransferSource::Address(Address::from(&source.public_key)),
@@ -180,6 +181,7 @@ async fn gen_transfer<'a>(
         native_token,
         amount,
     )
+        .await
         .signing_keys(vec![source.private_key.clone()])
         .fee_amount(InputAmount::from_str("0.5").unwrap())
         .gas_limit(1.into());
@@ -188,39 +190,39 @@ async fn gen_transfer<'a>(
         .await
         .expect("unable to build transfer");
     namada.sign(&mut transfer_tx, &transfer_tx_builder.tx, signing_data)
-            .expect("unable to sign reveal pk tx");
+        .await
+        .expect("unable to sign reveal pk tx");
     namada.submit(transfer_tx, &transfer_tx_builder.tx).await
 }
 
 async fn gen_actions<'a>(
-    namada: &mut impl Namada<'a>,
+    namada: &impl Namada<'a>,
     accounts: &Vec<Account>,
     repeats: usize,
 ) {
     let mut rand_gen = rand::thread_rng();
 
-    let mut txs = vec![];
+    let mut txs: Vec<Pin<Box<dyn Future<Output = _>>>> = vec![];
 
     for _ in 0..repeats {
         let rand_one = rand_gen.gen_range(0..accounts.len());
         let rand_two = rand_gen.gen_range(0..accounts.len());
 
         if accounts[rand_one].balance < Amount::from(1_000_000) {
-            txs.push(get_funds_from_faucet(namada, &accounts[rand_one]).await);
-            continue;
+            txs.push(Box::pin(get_funds_from_faucet(namada, &accounts[rand_one])));
+        } else {
+            let balance = u128::try_from(accounts[rand_one].balance).unwrap();
+            let native_token = namada.native_token().await;
+            let amount = denominate_amount(
+                namada.client(),
+                &native_token,
+                Amount::from_uint(Uint::from(rand_gen.gen_range(0..balance)),0).unwrap(),
+            ).await.into();
+            txs.push(Box::pin(gen_transfer(namada, &accounts[rand_one], &accounts[rand_two], amount)));
         }
-
-        let balance = u128::try_from(accounts[rand_one].balance).unwrap();
-        let native_token = namada.native_token();
-        let amount = denominate_amount(
-            namada.client,
-            &native_token,
-            Amount::from_uint(Uint::from(rand_gen.gen_range(0..balance)),0).unwrap(),
-        ).await.into();
-        txs.push(gen_transfer(namada, &accounts[rand_one], &accounts[rand_two], amount).await);
     }
 
-    for o in txs {
+    for o in join_all(txs).await {
         println!("Tx Result: {:?}", o);
     }
 }
@@ -236,8 +238,8 @@ async fn main() -> std::io::Result<()> {
     let mut wallet = FsWalletUtils::new(PathBuf::from("wallet.toml"));
     let mut namada = NamadaImpl::new(&http_client, &mut wallet, &mut shielded_ctx)
         .chain_id(ChainId::from_str(CHAIN_ID).unwrap());
-    let mut accounts = gen_accounts(&mut namada, 100);
-    update_token_balances(&mut namada, &mut accounts).await;
+    let mut accounts = gen_accounts(&mut namada, 100).await;
+    update_token_balances(&namada, &mut accounts).await;
     for account in &accounts {
         println!(
             "Address: {:?} - Balance: {:?} - Revealed: {:?}",
@@ -247,7 +249,6 @@ async fn main() -> std::io::Result<()> {
         );
     }
     reveal_pks(&mut namada, &mut accounts).await;
-    let initial_accounts = accounts.clone();
 
     let mut counter = 0;
 
@@ -277,159 +278,5 @@ async fn main() -> std::io::Result<()> {
         counter += 1;
 
         println!("Counter: {:?}", counter);
-        // if counter == 3 {
-        //     break
-        // }
     }
-    /*
-       - create a configurable number of accounts
-       - send a configurable number of transactions between these accounts without PoW challenge
-       - after each set of transactions, update the balance on the account structure
-    */
-
-    // println!("alive");
-    // fs::remove_file("wallet.toml").await;
-    // println!("alive");
-    //
-    // println!("alive");
-    //
-    // loop {
-
-    //     println!("alive");
-    //     let accounts = gen_accounts(&mut wallet, 10);
-    //     println!("alive");
-    //     let actions = gen_actions(accounts, 25);
-    //     println!("alive");
-    //     // let futures: Vec<_> = actions.into_iter().map(|action| {
-    //     //     tx::submit_transfer(&http_client, &mut wallet, &mut shielded_ctx, action)
-    //     // }).collect();
-    //
-    //     let mut futures = vec![];
-    //     for a in actions {
-    //         let wallet = gen_or_load_wallet(PathBuf::from("wallet.toml"));
-    //         let shielded_ctx = SdkShieldedUtils::new(Path::new("masp/").to_path_buf());
-    //         let tx = tx::submit_transfer(&http_client, wallet, shielded_ctx, a);
-    //         futures.push(tx);
-    //     }
-    //     println!("alive");
-    //
-    //     let outputs = join_all(futures).await;
-    //
-    //     for o in outputs {
-    //         println!("Tx Result: {:?}", o);
-    //     }
-    //
-    //     // break;
-    //     let sleep = time::Duration::from_secs(15);
-    //     println!("Sleeping");
-    //     thread::sleep(sleep);
-    //
-    //     fs::remove_file("wallet.toml").await;
-    //     println!("Next Iteration");
-    // }
-
-    // let key_alias_0 = "default0".to_owned();
-    // let key_alias_1 = "default1".to_owned();
-    // let key_alias_2 = "default2".to_owned();
-    //
-    // println!(
-    //     "Alias: {:?} :: Address: {:?}",
-    //     &key_alias_0,
-    //     wallet.find_address(&key_alias_0).unwrap()
-    // );
-    // println!(
-    //     "Alias: {:?} :: Address: {:?}",
-    //     &key_alias_1,
-    //     wallet.find_address(&key_alias_1).unwrap()
-    // );
-    // println!(
-    //     "Alias: {:?} :: Address: {:?}",
-    //     &key_alias_2,
-    //     wallet.find_address(&key_alias_2).unwrap()
-    // );
-    //
-    // let native_token = Address::from_str(
-    //     "atest1v4ehgw36x3prswzxggunzv6pxqmnvdj9xvcyzvpsggeyvs3cg9qnywf589qnwvfsg5erg3fkl09rg5",
-    // )
-    // .expect("Unable to construct native token");
-    // let faucet = Address::from_str(
-    //     "atest1v4ehgw36gc6yxvpjxccyzvphxycrxw2xxsuyydesxgcnjs3cg9znwv3cxgmnj32yxy6rssf5tcqjm3",
-    // )
-    // .expect("Should work");
-    // let chain_id = ChainId::from_str("public-testnet-10.3718993c3648").unwrap();
-    //
-    // let tendermint_addr =
-    //     TendermintAddress::from_str("127.0.0.1:26757").expect("Unable to connect to RPC");
-    // let http_client = HttpClient::new(tendermint_addr).unwrap();
-    // let block_res = rpc::query_block(&http_client).await;
-    // println!("Query Block: {:?}", block_res);
-    //
-    // let init_tx = args::TxInitAccount {
-    //     tx: args::Tx {
-    //         dry_run: false,
-    //         dump_tx: false,
-    //         force: false,
-    //         broadcast_only: false,
-    //         ledger_address: (),
-    //         initialized_account_alias: Some("default0_account".to_owned()),
-    //         wallet_alias_force: false,
-    //         fee_amount: 0.into(),
-    //         fee_token: native_token.clone(),
-    //         gas_limit: 0.into(),
-    //         expiration: None,
-    //         chain_id: Some(chain_id.clone()),
-    //         signing_key: Some(wallet.find_key(&key_alias_0, Some(Zeroizing::new("".to_owned()))).unwrap()),
-    //         signer: None,
-    //         tx_reveal_code_path: PathBuf::from("tx_reveal_pk.wasm"),
-    //         password: None,
-    //     },
-    //     source: wallet.find_address(&key_alias_0).unwrap().clone(),
-    //     vp_code_path: PathBuf::from("vp_user.wasm"),
-    //     tx_code_path: PathBuf::from("tx_init_account.wasm"),
-    //     public_key: wallet.find_key(&key_alias_0, Some(Zeroizing::new("".to_owned()))).unwrap().clone().to_public(),
-    // };
-    //
-    // let init_acc_res = tx::submit_init_account(&http_client, &mut wallet, init_tx).await;
-    // println!("Tx Result: {:?}", init_acc_res);
-    //
-    // let transfer_tx = args::TxTransfer {
-    //     tx: args::Tx {
-    //         dry_run: false,
-    //         dump_tx: false,
-    //         force: false,
-    //         broadcast_only: false,
-    //         ledger_address: (),
-    //         initialized_account_alias: None,
-    //         wallet_alias_force: false,
-    //         fee_amount: 0.into(),
-    //         fee_token: native_token.clone(),
-    //         gas_limit: 0.into(),
-    //         expiration: None,
-    //         chain_id: Some(chain_id.clone()),
-    //         signing_key: Some(wallet.find_key(&key_alias_1, Some(Zeroizing::new("".to_owned()))).unwrap()),
-    //         signer: None,
-    //         tx_reveal_code_path: PathBuf::from("tx_reveal_pk.wasm"),
-    //         password: None,
-    //     },
-    //     source: TransferSource::Address(faucet),
-    //     target: TransferTarget::Address(wallet.find_address(&key_alias_1).unwrap().clone()),
-    //     token: native_token.clone(),
-    //     sub_prefix: None,
-    //     amount: 444853442.into(),
-    //     native_token: native_token.clone(),
-    //     tx_code_path: PathBuf::from("tx_transfer.wasm"),
-    // };
-    //
-    // let transfer_tx_res = tx::submit_transfer(&http_client, &mut wallet, &mut shielded_ctx, transfer_tx).await;
-    // println!("Tx Result: {:?}", transfer_tx_res);
-    //
-    // let balance_res = rpc::get_token_balance(
-    //     &http_client,
-    //     &native_token,
-    //     wallet.find_address(&key_alias_1).unwrap(),
-    // )
-    //     .await;
-    // println!("Balance {:?}", balance_res);
-
-    //Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,11 @@
 use async_std::fs;
+use futures::future::join_all;
+use std::future::Future;
 use std::path::Path;
 use std::path::PathBuf;
+use std::pin::Pin;
 use std::str::FromStr;
 use std::{thread, time, vec};
-use std::future::Future;
-use futures::future::join_all;
-use std::pin::Pin;
 
 use rand::Rng;
 use tendermint_config::net::Address as TendermintAddress;
@@ -13,31 +13,36 @@ use tendermint_rpc::HttpClient;
 use zeroize::Zeroizing;
 
 use namada::bip39::Mnemonic;
-use namada::ledger::wallet::fs::FsWalletUtils;
-use namada::ledger::rpc;
-use namada::ledger::masp::fs::FsShieldedUtils;
+use namada::ledger::Namada;
+use namada::ledger::NamadaImpl;
+use namada::sdk::args::InputAmount;
+use namada::sdk::args::TxBuilder;
+use namada::sdk::masp::fs::FsShieldedUtils;
+use namada::sdk::rpc;
+use namada::sdk::rpc::{denominate_amount, format_denominated_amount as format_amount};
+use namada::sdk::tx::ProcessTxResponse;
+use namada::sdk::wallet::fs::FsWalletUtils;
 use namada::types::address::Address;
 use namada::types::chain::ChainId;
+use namada::types::io::StdIo;
+use namada::types::key::common::SecretKey;
 use namada::types::key::{common, SchemeType};
 use namada::types::masp::TransferSource;
 use namada::types::masp::TransferTarget;
 use namada::types::token::Amount;
-use namada::ledger::NamadaImpl;
-use namada::ledger::Namada;
-use namada::ledger::args::TxBuilder;
-use namada::ledger::tx::ProcessTxResponse;
-use namada::ledger::args::InputAmount;
 use namada::types::uint::Uint;
-use namada::ledger::rpc::denominate_amount;
 
 const MNEMONIC_CODE: &str = "cruise ball fame lucky fabric govern \
                             length fruit permit tonight fame pear \
                             horse park key chimney furnace lobster \
                             foot example shoot dry fuel lawn";
 
-const CHAIN_ID: &str = "public-testnet-10.3718993c3648";
+const CHAIN_ID: &str = "e2e-test.1247e85aaaec9e80e7051";
+const NATIVE_TOKEN: &str =
+    "atest1v4ehgw36x3prswzxggunzv6pxqmnvdj9xvcyzvpsggeyvs3cg9qnywf589qnwvfsg5erg3fkl09rg5";
 const FAUCET: &str =
-    "atest1v4ehgw36gc6yxvpjxccyzvphxycrxw2xxsuyydesxgcnjs3cg9znwv3cxgmnj32yxy6rssf5tcqjm3";
+    "atest1v4ehgw36gge5x33cxc6rg3p3xueyyv2989ryxdzyggunzs3kxgcn2dfegymnqdenx5e5xdec6uc56q";
+const FAUCET_KEY: &str = "006616290a9ad448cc7858a44df5d71f6ddad10c08d4a23470617e574ef9f71a2e";
 /*
 
 - generate X number of wallets
@@ -58,27 +63,25 @@ const FAUCET: &str =
 
 #[derive(Clone)]
 struct Account {
-    key_alias: String,
     public_key: common::PublicKey,
     private_key: common::SecretKey,
     balance: Amount,
     revealed: bool,
 }
 
-// initialize each account with it's state; includes
-// - it's public and private key
-// - it's NAM balance
-// - check if it's PK has been revealed and if not, reveal it, otherwise reveal them
-// - returns a list of futures with potential revelations that need to be run first and update the account structure - this should only happen on the very first run
+// Generate the given number of accounts and load each up with a preset number
+// of native tokens from the faucet
 async fn gen_accounts<'a>(namada: &mut impl Namada<'a>, size: usize) -> Vec<Account> {
     let mut accounts: Vec<Account> = vec![];
     let mnemonic = Mnemonic::from_phrase(MNEMONIC_CODE, namada::bip39::Language::English)
         .expect("unable to construct mnemonic");
+    let mut txs: Vec<Pin<Box<dyn Future<Output = _>>>> = vec![];
 
+    // Create the given number of accounts
     for i in 0..size {
         let derivation_path = format!("m/44'/877'/0'/0'/{}'", i);
         let alias = format!("default_{}", i);
-        let (key_alias, sk) = namada
+        let (_key_alias, sk) = namada
             .wallet_mut()
             .await
             .derive_key_from_user_mnemonic_code(
@@ -92,7 +95,6 @@ async fn gen_accounts<'a>(namada: &mut impl Namada<'a>, size: usize) -> Vec<Acco
             .expect("unable to derive key from mnemonic code")
             .unwrap();
         let account = Account {
-            key_alias,
             public_key: sk.to_public(),
             private_key: sk,
             balance: Amount::from(0),
@@ -100,32 +102,39 @@ async fn gen_accounts<'a>(namada: &mut impl Namada<'a>, size: usize) -> Vec<Acco
         };
         accounts.push(account);
     }
+    // Preload them with a preset number of tokens
+    for account in &accounts {
+        txs.push(Box::pin(get_funds_from_faucet(namada, account)));
+    }
+
+    // Wait for all the accounts to finish being loaded and display results
+    for output in join_all(txs).await {
+        println!("Tx Result: {:?}", output);
+    }
+    // Save the new accounts in the wallet
     namada.wallet().await.save().expect("unable to save wallet");
     accounts
 }
 
-async fn update_token_balances<'a>(
-    namada: &impl Namada<'a>,
-    accounts: &mut Vec<Account>,
-) {
+// Query the current account balances from the network
+async fn update_token_balances<'a>(namada: &impl Namada<'a>, accounts: &mut Vec<Account>) {
     for account in accounts {
         account.balance = rpc::get_token_balance(
             namada.client(),
-            &namada.native_token().await,
+            &Address::from_str(NATIVE_TOKEN).unwrap(),
             &Address::from(&account.public_key),
         )
-        .await.expect("unable to query account balance");
+        .await
+        .expect("unable to query account balance");
     }
 }
 
-/*
-   - check if need to reveal and if not, then don't reveal
-*/
-async fn reveal_pks<'a>(
-    namada: &mut impl Namada<'a>,
-    accounts: &mut Vec<Account>,
-) {
-    for mut account in accounts {
+// Submit transactions to reveal the public key of each account
+async fn reveal_pks<'a>(namada: &mut impl Namada<'a>, accounts: &mut Vec<Account>) {
+    let mut reveal_builders = Vec::new();
+    let mut txs: Vec<Pin<Box<dyn Future<Output = _>>>> = vec![];
+    // Construct and sign all the reveal PK transactions
+    for account in accounts.iter() {
         let reveal_tx_builder = namada
             .new_reveal_pk(account.public_key.clone())
             .await
@@ -134,72 +143,83 @@ async fn reveal_pks<'a>(
             .build(namada)
             .await
             .expect("unable to build reveal pk tx");
-        namada.sign(&mut reveal_tx, &reveal_tx_builder.tx, signing_data)
+        namada
+            .sign(&mut reveal_tx, &reveal_tx_builder.tx, signing_data)
             .await
             .expect("unable to sign reveal pk tx");
-        let res = namada.submit(reveal_tx, &reveal_tx_builder.tx).await;
+        reveal_builders.push((reveal_tx, reveal_tx_builder.tx));
+    }
+    // Submit all of the reveal PK transactions
+    for (reveal_tx, reveal_tx_builder) in reveal_builders.iter() {
+        txs.push(namada.submit(reveal_tx.clone(), reveal_tx_builder));
+    }
+    // Wait for all the public keys to be revealed and display results
+    for (account, res) in accounts.iter_mut().zip(join_all(txs).await.iter()) {
         account.revealed |= res.is_ok();
+        println!("Tx Result: {:?}", res);
     }
 }
 
+// Load a preset amount of tokens from the faucet into the given account
 async fn get_funds_from_faucet<'a>(
     namada: &impl Namada<'a>,
     account: &Account,
-) -> std::result::Result<ProcessTxResponse, namada::types::error::Error> {
+) -> std::result::Result<ProcessTxResponse, namada::sdk::error::Error> {
     let faucet = Address::from_str(FAUCET).unwrap();
-    let native_token = namada.native_token().await;
 
-    let mut transfer_tx_builder = namada.new_transfer(
-        TransferSource::Address(faucet.clone()),
-        TransferTarget::Address(Address::from(&account.public_key)),
-        native_token,
-        InputAmount::from_str("1000").unwrap(),
-    )
+    let mut transfer_tx_builder = namada
+        .new_transfer(
+            TransferSource::Address(faucet.clone()),
+            TransferTarget::Address(Address::from(&account.public_key)),
+            Address::from_str(NATIVE_TOKEN).unwrap(),
+            InputAmount::from_str("1000").unwrap(),
+        )
         .await
-        .signing_keys(vec![account.private_key.clone()]);
+        .signing_keys(vec![SecretKey::from_str(FAUCET_KEY).unwrap()]);
     let (mut transfer_tx, signing_data, _epoch) = transfer_tx_builder
         .build(namada)
         .await
         .expect("unable to build transfer");
-    namada.sign(&mut transfer_tx, &transfer_tx_builder.tx, signing_data)
+    namada
+        .sign(&mut transfer_tx, &transfer_tx_builder.tx, signing_data)
         .await
         .expect("unable to sign reveal pk tx");
     namada.submit(transfer_tx, &transfer_tx_builder.tx).await
 }
 
+// Transfer the given amount of native tokens from the source account to the
+// destination account.
 async fn gen_transfer<'a>(
     namada: &impl Namada<'a>,
     source: &Account,
     destination: &Account,
     amount: InputAmount,
-) -> std::result::Result<ProcessTxResponse, namada::types::error::Error> {
-    let native_token = namada.native_token().await;
-    
-    let mut transfer_tx_builder = namada.new_transfer(
-        TransferSource::Address(Address::from(&source.public_key)),
-        TransferTarget::Address(Address::from(&destination.public_key)),
-        native_token,
-        amount,
-    )
+) -> std::result::Result<ProcessTxResponse, namada::sdk::error::Error> {
+    let mut transfer_tx_builder = namada
+        .new_transfer(
+            TransferSource::Address(Address::from(&source.public_key)),
+            TransferTarget::Address(Address::from(&destination.public_key)),
+            Address::from_str(NATIVE_TOKEN).unwrap(),
+            amount,
+        )
         .await
-        .signing_keys(vec![source.private_key.clone()])
-        .fee_amount(InputAmount::from_str("0.5").unwrap())
-        .gas_limit(1.into());
+        .signing_keys(vec![source.private_key.clone()]);
     let (mut transfer_tx, signing_data, _epoch) = transfer_tx_builder
         .build(namada)
         .await
         .expect("unable to build transfer");
-    namada.sign(&mut transfer_tx, &transfer_tx_builder.tx, signing_data)
+    namada
+        .sign(&mut transfer_tx, &transfer_tx_builder.tx, signing_data)
         .await
         .expect("unable to sign reveal pk tx");
     namada.submit(transfer_tx, &transfer_tx_builder.tx).await
 }
 
-async fn gen_actions<'a>(
-    namada: &impl Namada<'a>,
-    accounts: &Vec<Account>,
-    repeats: usize,
-) {
+// Rnadomly select pairs of accounts and transfer a random amount of native
+// tokens from the first to the second in those cases where the source balance
+// exceeds 1 NAM. Otherwise reload a preset amount of native tokens into the
+// source account from the faucet.
+async fn gen_actions<'a>(namada: &impl Namada<'a>, accounts: &Vec<Account>, repeats: usize) {
     let mut rand_gen = rand::thread_rng();
 
     let mut txs: Vec<Pin<Box<dyn Future<Output = _>>>> = vec![];
@@ -209,74 +229,107 @@ async fn gen_actions<'a>(
         let rand_two = rand_gen.gen_range(0..accounts.len());
 
         if accounts[rand_one].balance < Amount::from(1_000_000) {
+            // Initiate a fund reload from the faucet
             txs.push(Box::pin(get_funds_from_faucet(namada, &accounts[rand_one])));
         } else {
+            // Generate a random amount that is less than the source balance
             let balance = u128::try_from(accounts[rand_one].balance).unwrap();
-            let native_token = namada.native_token().await;
             let amount = denominate_amount(
-                namada.client(),
-                &native_token,
-                Amount::from_uint(Uint::from(rand_gen.gen_range(0..balance)),0).unwrap(),
-            ).await.into();
-            txs.push(Box::pin(gen_transfer(namada, &accounts[rand_one], &accounts[rand_two], amount)));
+                namada,
+                &Address::from_str(NATIVE_TOKEN).unwrap(),
+                Amount::from_uint(Uint::from(rand_gen.gen_range(0..balance)), 0).unwrap(),
+            )
+            .await
+            .into();
+            // Initiate the transfer from the source to the destination
+            txs.push(Box::pin(gen_transfer(
+                namada,
+                &accounts[rand_one],
+                &accounts[rand_two],
+                amount,
+            )));
         }
     }
 
-    for o in join_all(txs).await {
-        println!("Tx Result: {:?}", o);
+    // Wait until all the transactions have completed
+    for output in join_all(txs).await {
+        println!("Tx Result: {:?}", output);
     }
 }
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
+    // Setup client
     let tendermint_addr =
-        TendermintAddress::from_str("127.0.0.1:26757").expect("Unable to connect to RPC");
+        TendermintAddress::from_str("127.0.0.1:27657").expect("Unable to connect to RPC");
     let http_client = HttpClient::new(tendermint_addr).unwrap();
-
     let _ = fs::remove_file("wallet.toml").await;
-    let mut shielded_ctx = FsShieldedUtils::new(Path::new("masp/").to_path_buf());
+    // Setup wallet storage
     let mut wallet = FsWalletUtils::new(PathBuf::from("wallet.toml"));
-    let mut namada = NamadaImpl::new(&http_client, &mut wallet, &mut shielded_ctx)
-        .chain_id(ChainId::from_str(CHAIN_ID).unwrap());
-    let mut accounts = gen_accounts(&mut namada, 100).await;
+    // Setup shielded context storage
+    let mut shielded_ctx = FsShieldedUtils::new(Path::new("masp/").to_path_buf());
+    let nam = Address::from_str(NATIVE_TOKEN).unwrap();
+    // Setup the Namada context
+    let mut namada = NamadaImpl::new(&http_client, &mut wallet, &mut shielded_ctx, &StdIo)
+        .chain_id(ChainId::from_str(CHAIN_ID).unwrap())
+        .fee_token(nam.clone());
+    // Generate 500 accounts
+    let mut accounts = gen_accounts(&mut namada, 500).await;
+    // Record their balances and display
     update_token_balances(&namada, &mut accounts).await;
     for account in &accounts {
         println!(
-            "Address: {:?} - Balance: {:?} - Revealed: {:?}",
+            "Address: {:?} - Balance: {} - Revealed: {:?}",
             Address::from(&account.public_key),
-            account.balance,
+            format_amount(&namada, &nam, account.balance).await,
             account.revealed
         );
     }
+    // Reveal all the account public keys
     reveal_pks(&mut namada, &mut accounts).await;
 
-    let mut counter = 0;
-
-    loop {
-        println!("+++++ Starting the loop +++++");
+    for counter in 0.. {
+        println!("+++++ Starting loop {} +++++", counter);
+        // Record and display all the account balances
         update_token_balances(&mut namada, &mut accounts).await;
         let initial_accounts = accounts.clone();
         for account in &initial_accounts {
-            println!("Address: {:?} - Balance: {:?} - Revealed: {:?}", Address::from(&account.public_key), account.balance, account.revealed);
+            println!(
+                "Address: {:?} - Balance: {} - Revealed: {:?}",
+                Address::from(&account.public_key),
+                format_amount(&namada, &nam, account.balance).await,
+                account.revealed,
+            );
         }
 
+        // Execute some random actions involving the accounts
         gen_actions(&mut namada, &accounts, 15).await;
 
         let sleep = time::Duration::from_secs(1);
         println!("Sleeping");
         thread::sleep(sleep);
 
+        // Record and display all the account balance changes
         update_token_balances(&mut namada, &mut accounts).await;
         for i in 0..accounts.len() {
-            println!("Address: {:?} - Old Balance: {:?} - New Balance: {:?} - Difference: {:?}", Address::from(&accounts[i].public_key), initial_accounts[i].balance, accounts[i].balance, initial_accounts[i].balance.checked_sub(accounts[i].balance));
+            let (sign, diff) = if initial_accounts[i].balance > accounts[i].balance {
+                ('-', initial_accounts[i].balance - accounts[i].balance)
+            } else {
+                ('+', accounts[i].balance - initial_accounts[i].balance)
+            };
+            println!(
+                "Address: {:?} - Old Balance: {} - New Balance: {} - Difference: {}{}",
+                Address::from(&accounts[i].public_key),
+                format_amount(&namada, &nam, initial_accounts[i].balance).await,
+                format_amount(&namada, &nam, accounts[i].balance).await,
+                sign,
+                format_amount(&namada, &nam, diff).await,
+            );
         }
 
         let sleep = time::Duration::from_secs(15);
         println!("Sleeping");
         thread::sleep(sleep);
-
-        counter += 1;
-
-        println!("Counter: {:?}", counter);
     }
+    Ok(())
 }


### PR DESCRIPTION
Updated this Namada SDK starter to use the updated SDK ( https://github.com/anoma/namada/pull/1963 ) as a means of demonstrating the latter's usage. Specifically the following changes have been made to this starter:
* The wallet and shielded context no longer have to be reloaded from file storage for each asynchronous transfer task. Instead each task obtains a lock on the wallet and shielded context whenever it needs them.
* It is no longer necessary to supply all fields of a transaction in order to generate one since the SDK provides defaults (similar to those in the CLI). As a result, much less fields are being explicitly initialized in this starter.
* The transactions to reveal the public keys of each account have been parallelized in order to speed up that process.
* The building, signing, and submission of transactions to the network have been split up into separate steps in order to give the user flexibility in how they sign transactions.
* The SDK's `format_denominated_amount` method is now being used to display the account balances in terms more readable than micro-units.
* Added comments and removed dead code.
* The wallet/shielded context loading and saving to file storage functionality is no longer implemented here as it has been implemented inside the SDK and exposed through a trait.